### PR TITLE
Update api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ flex
 *.mkv
 *.swp
 *.*.swp
+.env
+.env.local

--- a/flex-backend/.env
+++ b/flex-backend/.env
@@ -1,1 +1,0 @@
-dataDir="./Movies"

--- a/flex-backend/Dockerfile
+++ b/flex-backend/Dockerfile
@@ -1,0 +1,11 @@
+from golang:1.20
+
+workdir /app
+
+copy . .
+
+run go build *.go
+
+expose 8080
+
+cmd ["./main"]

--- a/flex-backend/Makefile
+++ b/flex-backend/Makefile
@@ -4,4 +4,16 @@ run:
 	go run ./main.go
 
 build:
-	go build .
+	go build -o flex *.go
+
+docker:
+	docker build -t flex:latest .
+
+up:
+	docker run --name flex -dt -p 8080:8080 flex
+
+down:
+	docker rm -f flex
+
+logs:
+	docker logs -f flex

--- a/flex-backend/api/http/server.go
+++ b/flex-backend/api/http/server.go
@@ -27,7 +27,7 @@ func (s Server) BuildEndpoints() {
 func (Server) Serve(port int) {
 	// Start the server
 	log.Printf("Starting server on port %d\n", port)
-	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", port), nil))
+	log.Fatal(http.ListenAndServe(fmt.Sprintf("0.0.0.0:%d", port), nil))
 }
 
 func handleSendRoot(w http.ResponseWriter, r *http.Request) {

--- a/flex-backend/api/http/server.go
+++ b/flex-backend/api/http/server.go
@@ -2,9 +2,8 @@ package flexapi
 
 import (
 	"encoding/json"
-	"flex/movie"
+	movie "flex/movieHandler"
 	"fmt"
-	"html"
 	"log"
 	"net/http"
 )
@@ -68,6 +67,7 @@ func (s Server) handleGetMovieInfo(w http.ResponseWriter, r *http.Request) {
 		log.Println(err)
 	}
 
+	// Size is the number of bytes within the file (1000000 bytes = 1MB)
 	type movieInfoResponse struct {
 		Name string
 		Size int64
@@ -87,18 +87,4 @@ func (s Server) handleGetMovieInfo(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.Write(jData)
-}
-
-func handlePlayFile(w http.ResponseWriter, r *http.Request) {
-	// Start the ffmpeg stream from the specified file in the request.
-	// Would we want to attach a session id to the process so we know who is playing what in the future?
-	fmt.Fprintf(w, "Hello, %q", html.EscapeString(r.URL.Path))
-	fmt.Println("Called play movie route!")
-}
-
-func handleStopFile(w http.ResponseWriter, r *http.Request) {
-	// Stop the ffmpeg stream from the specified file in the request.
-	// Would we want to attach a session id to the process so we know how to stop the stream?
-	fmt.Fprintf(w, "Hello, %q", html.EscapeString(r.URL.Path))
-	fmt.Println("Called stop movie route!")
 }

--- a/flex-backend/api/http/server.go
+++ b/flex-backend/api/http/server.go
@@ -2,10 +2,11 @@ package flexapi
 
 import (
 	"encoding/json"
-	movie "flex/movieHandler"
 	"fmt"
 	"log"
 	"net/http"
+
+	movie "github.com/kcpetersen111/flex/movieHandler"
 )
 
 // we will want to use a builder pattern to configure the server

--- a/flex-backend/api/http/server.go
+++ b/flex-backend/api/http/server.go
@@ -44,6 +44,8 @@ func (s Server) handleGetMovies(w http.ResponseWriter, r *http.Request) {
 	jData, err := json.Marshal(files)
 	if err != nil {
 		log.Println(err)
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("500 - Something bad happened!"))
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.Write(jData)

--- a/flex-backend/api/http/websockets.go
+++ b/flex-backend/api/http/websockets.go
@@ -2,6 +2,7 @@ package flexapi
 
 import (
 	"fmt"
+	"html"
 	"log"
 	"net/http"
 
@@ -41,4 +42,19 @@ func (s Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+}
+
+// I think the play and stop handlers need to be implemented within the websocket
+func handlePlayFile(w http.ResponseWriter, r *http.Request) {
+	// Start the ffmpeg stream from the specified file in the request.
+	// Would we want to attach a session id to the process so we know who is playing what in the future?
+	fmt.Fprintf(w, "Hello, %q", html.EscapeString(r.URL.Path))
+	fmt.Println("Called play movie route!")
+}
+
+func handleStopFile(w http.ResponseWriter, r *http.Request) {
+	// Stop the ffmpeg stream from the specified file in the request.
+	// Would we want to attach a session id to the process so we know how to stop the stream?
+	fmt.Fprintf(w, "Hello, %q", html.EscapeString(r.URL.Path))
+	fmt.Println("Called stop movie route!")
 }

--- a/flex-backend/go.mod
+++ b/flex-backend/go.mod
@@ -1,4 +1,4 @@
-module flex
+module github.com/kcpetersen111/flex
 
 go 1.19
 

--- a/flex-backend/main.go
+++ b/flex-backend/main.go
@@ -2,10 +2,11 @@ package main
 
 import (
 	"flag"
-	server "flex/api/http"
-	"flex/movieHandler"
 	"log"
 	"os"
+
+	server "github.com/kcpetersen111/flex/api/http"
+	"github.com/kcpetersen111/flex/movieHandler"
 
 	"github.com/joho/godotenv"
 )

--- a/flex-backend/main.go
+++ b/flex-backend/main.go
@@ -34,15 +34,12 @@ func main() {
 
 	MovieHandler := movie.NewMovieHandler(path)
 
-	log.Println(MovieHandler)
-
 	MovieHandler.ListMovies()
 
 	server := server.Server{MovieHandler}
 
 	server.BuildEndpoints()
-	server.Serve()
+	server.Serve(port)
 
 	return
-
 }

--- a/flex-backend/main.go
+++ b/flex-backend/main.go
@@ -29,7 +29,7 @@ func main() {
 
 	if len(path) == 0 {
 		// Environment variable doesn't exist, set default
-		path = "./Movies"
+		path = "/Movies"
 	}
 	log.Printf("The path is: %s\n", path)
 

--- a/flex-backend/main.go
+++ b/flex-backend/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"flag"
 	server "flex/api/http"
-	"flex/movie"
+	"flex/movieHandler"
 	"log"
 	"os"
 
@@ -11,6 +11,7 @@ import (
 )
 
 func main() {
+	// Get line numbers in log messages
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
 
 	var sAddr string
@@ -28,11 +29,11 @@ func main() {
 
 	if len(path) == 0 {
 		// Environment variable doesn't exist, set default
-		path = "/Movies"
+		path = "./Movies"
 	}
 	log.Printf("The path is: %s\n", path)
 
-	MovieHandler := movie.NewMovieHandler(path)
+	MovieHandler := movieHandler.NewMovieHandler(path)
 
 	MovieHandler.ListMovies()
 

--- a/flex-backend/movie/helper.go
+++ b/flex-backend/movie/helper.go
@@ -1,7 +1,6 @@
 package movie
 
 import (
-	"bufio"
 	"fmt"
 	"log"
 	"os"
@@ -49,7 +48,6 @@ func (m MovieHandler) ReadLocalDir(root string) ([]string, error) {
 }
 
 func (m MovieHandler) ListMovies() {
-	log.Println("The path is", m.MovieDir)
 	_, err := os.Stat(m.MovieDir)
 	if os.IsNotExist(err) {
 		err = os.Mkdir(m.MovieDir, 0750)
@@ -67,17 +65,11 @@ func (m MovieHandler) ListMovies() {
 	fmt.Printf("Found these movies!\n%v\n", files)
 }
 
-func (m MovieHandler) getMovieInfo() {
-	fmt.Println("What would you like to watch?")
-	scanner := bufio.NewScanner(os.Stdin)
-	scanner.Scan()
-	t := scanner.Text()
-
-	moviePath := fmt.Sprintf("%s/%s", m.MovieDir, t)
+func (MovieHandler) GetMovieInfo(moviePath string) (os.FileInfo, error) {
 	movie, err := os.Stat(moviePath)
 	if err != nil {
-		log.Fatalf("There was an error: %v\n", err)
+		return nil, err
 	}
-	fmt.Printf("Movie name: %s\nMovie size: %d\nFile mode: %s\nLast modified: %s\n", movie.Name(), movie.Size(), movie.Mode(), movie.ModTime())
+	return movie, nil
 
 }

--- a/flex-backend/movieHandler/helper.go
+++ b/flex-backend/movieHandler/helper.go
@@ -1,4 +1,4 @@
-package movie
+package movieHandler
 
 import (
 	"fmt"


### PR DESCRIPTION
This rewrites some of the web socket stuff to be broken out to just an http endpoint. Now the web socket part of the code just acts like a ping / pong style of endpoint and will write back to the client what you send the server. 

The `getMovies` endpoint currently just returns each of the file paths to the client that it detects, while the `getMovieInfo` looks for a `movie` query parameter which is the complete file path to the video and returns some of the os.stat info about it (name, size in bytes, and file mode).